### PR TITLE
Fix #13 -  Use potential proxy for client if specified in env-vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,19 @@ jobs:
         uses: actions/checkout@main # don't get confused by @main - it is the version of the checkout action. You repo will be checked out with ${{ github.ref }}
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,16 +27,22 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@main
 
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: 'temurin'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         queries: security-and-quality
 
     # If this step fails, then you should remove it and run the build manually
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Special thanks goes to <a href="https://github.com/luechtdiode" target="_blank">
 <dependency>
   <groupId>com.baloise.open</groupId>
   <artifactId>ms-teams-connector</artifactId>
-  <version>0.2.3</version>
+  <version>0.3.0</version>
 </dependency>
 ```
 
@@ -66,3 +66,5 @@ MessageCardFactory.builder("A crisp title", "A little more descriptive text.")
 |PROPERTY_RETRY_PAUSE|60|Defines the pause time between PROPERTY_RETRIES in seconds. Accepts any positive integer > 0.|
 |PROPERTY_WEBHOOK_URI|none|The URI to your webhook. Required property provided either as String or URI.|
 
+### System Environment
+In case you need to connect via a proxy URL, you can specify a system environment variable named ``https_proxy``. 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and publish it to a MS-Teams channel via webhook.
 Special thanks goes to <a href="https://github.com/luechtdiode" target="_blank"><b>Roland Seidel</b></a> for the idea and his reference implementation.
 
 ## Change Log
-- Version 0.2.x is the last version supporting Java 8
+- Version 0.2.3 is the last version supporting Java 8
 
 
 ## Usage
@@ -18,7 +18,7 @@ Special thanks goes to <a href="https://github.com/luechtdiode" target="_blank">
 <dependency>
   <groupId>com.baloise.open</groupId>
   <artifactId>ms-teams-connector</artifactId>
-  <version>0.2.2</version>
+  <version>0.2.3</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,9 @@
   </distributionManagement>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <java.version>17</java.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <sonar.projectKey>baloise-incubator_ms-teams-connector</sonar.projectKey>
@@ -119,6 +120,10 @@
         <configuration>
           <argLine>${jacocoArgLine}</argLine>
           <reportsDirectory>${project.build.directory}/surefire</reportsDirectory>
+            <environmentVariables>
+              <https_proxy>http://webproxy.bla.com:3031</https_proxy>
+              <http_proxy>http://webproxy.bla.com:3031</http_proxy>
+            </environmentVariables>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
           <argLine>-Djava.net.useSystemProxies=true</argLine>
           <reportsDirectory>${project.build.directory}/surefire</reportsDirectory>
             <environmentVariables>
-              <https_proxy>http://webproxy.bla.com:3031</https_proxy>
+              <https_proxy>http://localhost:8080</https_proxy>
             </environmentVariables>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -116,13 +116,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M8</version>
+        <version>3.5.2</version>
         <configuration>
-          <argLine>${jacocoArgLine}</argLine>
+          <argLine>-Djava.net.useSystemProxies=true</argLine>
           <reportsDirectory>${project.build.directory}/surefire</reportsDirectory>
             <environmentVariables>
               <https_proxy>http://webproxy.bla.com:3031</https_proxy>
-              <http_proxy>http://webproxy.bla.com:3031</http_proxy>
             </environmentVariables>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -118,11 +118,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.2</version>
         <configuration>
-          <argLine>${jacocoArgLine} -Djava.net.useSystemProxies=true</argLine>
+          <argLine>${jacocoArgLine}</argLine>
           <reportsDirectory>${project.build.directory}/surefire</reportsDirectory>
-            <environmentVariables>
-              <https_proxy>http://localhost:8080</https_proxy>
-            </environmentVariables>
         </configuration>
       </plugin>
       <plugin>
@@ -190,6 +187,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.11.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>5.16.0</version>
@@ -211,6 +214,12 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>4.2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-jupiter</artifactId>
+      <version>2.1.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>com.baloise.open</groupId>
   <artifactId>ms-teams-connector</artifactId>
-  <version>0.2.4-SNAPSHOT</version>
+  <version>0.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>MS-TEAMS conenctor</name>
@@ -118,7 +118,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.2</version>
         <configuration>
-          <argLine>-Djava.net.useSystemProxies=true</argLine>
+          <argLine>${jacocoArgLine} -Djava.net.useSystemProxies=true</argLine>
           <reportsDirectory>${project.build.directory}/surefire</reportsDirectory>
             <environmentVariables>
               <https_proxy>http://localhost:8080</https_proxy>

--- a/src/main/java/com/baloise/open/ms/teams/webhook/MessagePublisherImpl.java
+++ b/src/main/java/com/baloise/open/ms/teams/webhook/MessagePublisherImpl.java
@@ -19,39 +19,39 @@ import com.baloise.open.ms.teams.Config;
 import com.baloise.open.ms.teams.templates.MessageCard;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import java.net.URI;
-import java.util.Optional;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.EntityBuilder;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 @Slf4j
 class MessagePublisherImpl implements MessagePublisher {
 
   private final Config config;
-  final ClassicHttpRequest httpPost;
+  final HttpPost httpPost;
 
   MessagePublisherImpl(final Map<String, Object> properties) {
     log.debug(properties.toString());
     config = new Config(properties);
-    httpPost = ClassicRequestBuilder.post(config.getWebhookURI()).build();
+    httpPost = new HttpPost(config.getWebhookURI());
   }
 
   @Override
@@ -65,16 +65,18 @@ class MessagePublisherImpl implements MessagePublisher {
     return scheduleMessagePublishing(jsonBody, httpPost);
   }
 
-  ScheduledFuture<?> scheduleMessagePublishing(String jsonBody, ClassicHttpRequest httpPost) {
+  ScheduledFuture<?> scheduleMessagePublishing(String jsonBody, HttpPost httpPost) {
     httpPost.setEntity(EntityBuilder.create()
         .setText(jsonBody)
         .setContentType(ContentType.APPLICATION_JSON)
         .setContentEncoding(StandardCharsets.UTF_8.name()).build());
 
     final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-    final HttpClientPostExecutor httpClientPostExec = new HttpClientPostExecutor(httpPost,
-        executor);
-    return executor.scheduleWithFixedDelay(httpClientPostExec, 0, config.getPauseBetweenRetries(),
+    final HttpClientPostExecutor httpClientPostExec = new HttpClientPostExecutor(httpPost, executor);
+    return executor.scheduleWithFixedDelay(
+        httpClientPostExec,
+        0 /* no delay */,
+        config.getPauseBetweenRetries(),
         TimeUnit.MILLISECONDS);
   }
 
@@ -82,29 +84,41 @@ class MessagePublisherImpl implements MessagePublisher {
     return config;
   }
 
+  /**
+   * configure a HttpClient used in HttpClientPostExecutor, considering defined proxy settings
+   * set as environment variable in operated system environment.
+   *
+   */
+  private HttpClientBuilder getHttpClientBuilder() {
+    final Optional<String> proxyEntry = Stream.of(
+            System.getenv("https_proxy"),
+            System.getenv("HTTPS_PROXY"))
+        .filter(StringUtils::isNotBlank).findFirst();
+
+    final HttpHost optionalProxy = proxyEntry
+        .map(URI::create)
+        .map(HttpHost::create)
+        .orElse(null);
+
+    return HttpClientBuilder.create()
+        .useSystemProperties()
+        .setProxy(optionalProxy);
+  }
+
   private final class HttpClientPostExecutor implements Runnable {
 
     final ScheduledExecutorService scheduledExecutorService;
-    final ClassicHttpRequest httpPost;
+    final HttpPost httpPost;
     final AtomicInteger execCounter = new AtomicInteger(0);
 
-    HttpClientPostExecutor(final ClassicHttpRequest httpPost, ScheduledExecutorService executor) {
+    HttpClientPostExecutor(final HttpPost httpPost, ScheduledExecutorService executor) {
       this.scheduledExecutorService = executor;
       this.httpPost = httpPost;
     }
 
-    @SneakyThrows
     @Override
     public void run() {
-      try (final CloseableHttpClient httpclient = HttpClientBuilder.create()
-          .useSystemProperties()
-          .setProxy(Optional.ofNullable(System.getenv("https_proxy"))
-              .map(URI::create)
-              .map(HttpHost::create)
-              .orElse(null))
-          .build()
-      ) {
-
+      try (final CloseableHttpClient httpclient = getHttpClientBuilder().build()) {
         httpclient.execute(httpPost, response -> {
           final int responseCode = response.getCode();
 
@@ -119,19 +133,19 @@ class MessagePublisherImpl implements MessagePublisher {
           }
 
           log.debug(body);
-          throw new IllegalStateException(String.format(
-              "Posting data to %s may have failed. Webhook responded with status code %s",
-              config.getWebhookURI(), responseCode));
+          throw new IllegalStateException(
+              "Posting data to %s may have failed. Webhook responded with status code %s"
+                  .formatted(config.getWebhookURI(), responseCode));
         });
 
       } catch (Exception e) {
         log.warn(e.getMessage());
 
         if (config.getRetries() == execCounter.incrementAndGet()) {
-          log.warn(String.format("Giving up after %d attempts.", config.getRetries()));
+          log.warn("Giving up after {} attempts.", config.getRetries());
           cancel();
         } else {
-          log.info(String.format("Retry in %d seconds", config.getPauseBetweenRetries() / 1000));
+          log.info("Retry in {} seconds", config.getPauseBetweenRetries() / 1000);
         }
       }
     }

--- a/src/main/java/com/baloise/open/ms/teams/webhook/MessagePublisherImpl.java
+++ b/src/main/java/com/baloise/open/ms/teams/webhook/MessagePublisherImpl.java
@@ -89,7 +89,7 @@ class MessagePublisherImpl implements MessagePublisher {
 
     @Override
     public void run() {
-      try (final CloseableHttpClient httpclient = HttpClients.createDefault()) {
+      try (final CloseableHttpClient httpclient = HttpClients.createSystem()) {
 
         httpclient.execute(httpPost, response -> {
           final int responseCode = response.getCode();

--- a/src/test/java/com/baloise/open/ms/teams/webhook/MessagePublisherImplTest.java
+++ b/src/test/java/com/baloise/open/ms/teams/webhook/MessagePublisherImplTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mockito;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.configuration.ConfigurationProperties;
 import org.mockserver.junit.jupiter.MockServerExtension;
+import org.mockserver.junit.jupiter.MockServerSettings;
 import org.mockserver.matchers.Times;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
@@ -176,6 +177,7 @@ class MessagePublisherImplTest {
   @Nested
   @DisplayName("Test webhook MessagePublisher")
   @ExtendWith(MockServerExtension.class)
+  @MockServerSettings(ports = {8080})
   class MessagePublisherTest {
 
     private final String testMessage = "{\"title\":\"UnitTest\",\"content\":\"I should be some JSON content\"}";

--- a/src/test/java/com/baloise/open/ms/teams/webhook/MessagePublisherImplTest.java
+++ b/src/test/java/com/baloise/open/ms/teams/webhook/MessagePublisherImplTest.java
@@ -14,12 +14,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.configuration.ConfigurationProperties;
 import org.mockserver.junit.jupiter.MockServerExtension;
-import org.mockserver.junit.jupiter.MockServerSettings;
 import org.mockserver.matchers.Times;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
@@ -37,10 +38,12 @@ import java.util.concurrent.ScheduledFuture;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariable;
 
 class MessagePublisherImplTest {
 
@@ -177,7 +180,6 @@ class MessagePublisherImplTest {
   @Nested
   @DisplayName("Test webhook MessagePublisher")
   @ExtendWith(MockServerExtension.class)
-  @MockServerSettings(ports = {8080})
   class MessagePublisherTest {
 
     private final String testMessage = "{\"title\":\"UnitTest\",\"content\":\"I should be some JSON content\"}";
@@ -251,6 +253,38 @@ class MessagePublisherImplTest {
       client.reset();
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"https_proxy","HTTPS_PROXY", "ANY_other_sys_env_but_not_proxy"})
+    void testHttpClientUsesProxyWhenSetLowerCase(String sysEnvParamName, MockServerClient client) throws Exception {
+      final String proxyUrl = getExtractedUri(client);
+      withEnvironmentVariable(sysEnvParamName, proxyUrl).execute(() -> {
+        final HttpRequest mockedPost = HttpRequest.request().withMethod("POST");
+        client.when(mockedPost)
+            .respond(
+                HttpResponse.response().withBody("{}").withStatusCode(HttpStatus.SC_OK)
+            );
+
+        final String enpointUrl = getExtractedUriButWrongPort(client);
+        final MessagePublisherImpl testee = (MessagePublisherImpl) MessagePublisher.getInstance(enpointUrl + "/MYENDPOINT");
+        ScheduledFuture<?> publishedFuture = testee.publish(testMessage);
+        assertNotNull(publishedFuture);
+        Awaitility.await()
+            .atMost(Durations.TWO_SECONDS /* wait for executor service */)
+            .untilAsserted(() ->
+                client.verify(mockedPost
+                        .withBody(testMessage)
+                        .withContentType(MediaType.JSON_UTF_8),
+                    VerificationTimes.exactly(
+                        "https_proxy".equalsIgnoreCase(sysEnvParamName)
+                            ? 1 /* call succeeded via proxy */
+                            : 0 /* call failed since wrong port */ )));
+
+        assertTrue(testee.getConfig().getRetries() > 1);
+        assertNotEquals(proxyUrl, enpointUrl);
+        client.reset();
+      });
+    }
+
     @Test
     @DisplayName("POST is executed 2 times during failure")
     void test2RetriesInCaseOfFailure(MockServerClient client) throws InterruptedException {
@@ -301,9 +335,15 @@ class MessagePublisherImplTest {
     }
 
     private String getExtractedUri(MockServerClient client) {
-      return String.format("http://%s:%d",
+      return "http://%s:%d".formatted(
           client.remoteAddress().getAddress().getHostAddress(),
           client.remoteAddress().getPort());
+    }
+
+    private String getExtractedUriButWrongPort(MockServerClient client) {
+      return "http://%s:%d".formatted(
+          client.remoteAddress().getAddress().getHostAddress(),
+          client.remoteAddress().getPort()-1);
     }
   }
 }


### PR DESCRIPTION
Uses the https_proxy env-var (if provided) as the proxy for the HttpClient used to post message-cards. 
If the env-var is not present nothing changes. 
Bumps Java Version to 17. 