### PR TITLE
Add config property to make publish a blocking function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Special thanks goes to <a href="https://github.com/luechtdiode" target="_blank">
 
 ## Change Log
 
+- Version 0.5.0
+  - support blocking thread executor for batch / cli usage
+  - ⚠️ __Breaking__: removed deprecated config parameter
 - Version 0.4.0 is the first version supporting AdaptiveCards
 - Version 0.2.3 is the last version supporting Java 8
 
@@ -27,7 +30,7 @@ Special thanks goes to <a href="https://github.com/luechtdiode" target="_blank">
 <dependency>
   <groupId>com.baloise.open</groupId>
   <artifactId>ms-teams-connector</artifactId>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
 </dependency>
 ```
 
@@ -59,12 +62,13 @@ AdaptiveCardFactory.builder("A crisp title", "A little more descriptive text.")
 
 ## Configuration
 
-| Parameter            | Default | Description                                                                                                                         |
-|----------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------|
-| PROPERTY_RETRIES     | 3       | Defines the number of retries to publish the message in case of unsuccessful answer from webhook. Accepts any positive integer > 0. |
-| PROPERTY_RETRY_PAUSE | 60      | Defines the pause time between PROPERTY_RETRIES in seconds. Accepts any positive integer > 0.                                       |
-| PROPERTY_WEBHOOK_URI | none    | The URI to your webhook. Required property provided either as String or URI.                                                        |
-| PROPERTY_PROXY_URI   | none    | The URI to your web proxy.                                                                                                          |
+| Parameter            | Default | Description                                                                                                                               |
+|----------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY_RETRIES     | 3       | Defines the number of retries to publish the message in case of unsuccessful answer from webhook. Accepts any positive integer > 0.       |
+| PROPERTY_RETRY_PAUSE | 60      | Defines the pause time between PROPERTY_RETRIES in seconds. Accepts any positive integer > 0.                                             |
+| PROPERTY_WEBHOOK_URI | none    | The URI to your webhook. Required property provided either as String or URI.                                                              |
+| PROPERTY_PROXY_URI   | none    | The URI to your web proxy.                                                                                                                |
+| PROPERTY_BLOCKING    | false   | Set to ___true___ to block main thread until message was sent or max retries time is reached. Default is sending messages asynchronously. |
 
 ### System Environment
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>com.baloise.open</groupId>
   <artifactId>ms-teams-connector</artifactId>
-  <version>0.4.1-SNAPSHOT</version>
+  <version>0.5.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>MS-TEAMS Connector</name>

--- a/src/main/java/com/baloise/open/ms/teams/Config.java
+++ b/src/main/java/com/baloise/open/ms/teams/Config.java
@@ -21,126 +21,195 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.net.URI;
+import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
 @Getter
 public final class Config {
+    public static final long DEFAULT_PAUSE_BETWEEN_RETRIES = 60000;
+    public static final int DEFAULT_RETRIES = 3;
+    public static final boolean DEFAULT_BLOCKING = false;
 
-  /**
-   * defines the number of retires in case of technical interruptions
-   */
-  public static final String PROPERTY_RETRIES = "com.baloise.open.ms.teams.retries";
+    /**
+     * defines the number of retires in case of technical interruptions
+     */
+    public static final String PROPERTY_RETRIES = "com.baloise.open.ms.teams.retries";
 
-  /**
-   * defines the pause time between {@link #PROPERTY_RETRIES} in seconds
-   */
-  public static final String PROPERTY_RETRY_PAUSE = "com.baloise.open.ms.teams.retries.pause";
+    /**
+     * defines the pause time between {@link #PROPERTY_RETRIES} in seconds
+     */
+    public static final String PROPERTY_RETRY_PAUSE = "com.baloise.open.ms.teams.retries.pause";
 
-  /**
-   * defines the webhooks URI
-   */
-  public static final String PROPERTY_WEBHOOK_URI = "com.baloise.open.ms.teams.webhook.uri";
+    /**
+     * defines the webhooks URI
+     */
+    public static final String PROPERTY_WEBHOOK_URI = "com.baloise.open.ms.teams.webhook.uri";
 
-  /**
-   * defines the proxy URI
-   */
-  public static final String PROPERTY_PROXY_URI = "com.baloise.open.ms.teams.proxy.uri";
+    /**
+     * defines the proxy URI
+     */
+    public static final String PROPERTY_PROXY_URI = "com.baloise.open.ms.teams.proxy.uri";
 
-  private final int retries;
-  private final long pauseBetweenRetries;
-  private final URI webhookURI;
-  private final URI proxyURI;
+    /**
+     * defines if sending is blocking or not.
+     */
+    public static final String PROPERTY_BLOCKING = "com.baloise.open.ms.teams.execution.blocking";
 
-  public Config(final Map<String, Object> properties) {
-    retries = setRetries(properties);
-    pauseBetweenRetries = setPauseBetweenRetries(properties);
-    webhookURI = setWebhookURI(properties);
-    proxyURI = setProxyURI(properties);
-  }
+    private final int retries;
+    private final long pauseBetweenRetries;
+    private final URI webhookURI;
+    private final URI proxyURI;
+    private final boolean blocking;
 
-  private URI setWebhookURI(Map<String, Object> properties) {
-    if (properties == null || properties.get(PROPERTY_WEBHOOK_URI) == null) {
-      throw new IllegalArgumentException(String.format("Parameter %s must not be null.", PROPERTY_WEBHOOK_URI));
+    public Config(final Map<String, Object> properties) {
+        retries = setRetries(properties);
+        pauseBetweenRetries = setPauseBetweenRetries(properties);
+        webhookURI = setWebhookURI(properties);
+        proxyURI = setProxyURI(properties);
+        blocking = setBlocking(properties);
     }
 
-    final String stringValue = String.valueOf(properties.get(PROPERTY_WEBHOOK_URI));
-    if (StringUtils.isBlank(stringValue)) {
-      throw new IllegalArgumentException(String.format("Parameter %s must not be blank.", PROPERTY_WEBHOOK_URI));
-    }
-    try {
-      return URI.create(stringValue);
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException(String.format("Parameter %s must be a valid URI (%s): %s",
-          PROPERTY_WEBHOOK_URI,
-          stringValue,
-          e.getMessage()));
-    }
-  }
-
-  private URI setProxyURI(Map<String, Object> properties) {
-    final Object propertyObject = properties.get(PROPERTY_PROXY_URI);
-    final String stringValue = String.valueOf(propertyObject);
-
-    if (ObjectUtils.isNotEmpty(propertyObject) && StringUtils.isNotBlank(stringValue)) {
-      try {
-        return URI.create(stringValue);
-      } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException(String.format("Parameter %s must be a valid URI (%s): %s",
-                PROPERTY_PROXY_URI,
-                stringValue,
-                e.getMessage()));
-      }
-    }
-    return null;
-  }
-
-  private long setPauseBetweenRetries(Map<String, Object> properties) {
-    final long _default = 60000;
-    if (properties == null) {
-      return _default;
+    private boolean setBlocking(Map<String, Object> properties) {
+        if (properties != null) {
+            Object propertyBlocking = properties.get(PROPERTY_BLOCKING);
+            if (propertyBlocking != null) {
+                String stringValue = String.valueOf(propertyBlocking);
+                if (StringUtils.isNotBlank(stringValue)) {
+                    return Boolean.parseBoolean(stringValue);
+                }
+            }
+        }
+        return DEFAULT_BLOCKING;
     }
 
-    final Object o = properties.get(PROPERTY_RETRY_PAUSE);
-    if (o == null) {
-      return _default;
+    private URI setWebhookURI(Map<String, Object> properties) {
+        if (properties == null || properties.get(PROPERTY_WEBHOOK_URI) == null) {
+            throw new IllegalArgumentException(String.format("Parameter %s must not be null.", PROPERTY_WEBHOOK_URI));
+        }
+
+        final String stringValue = String.valueOf(properties.get(PROPERTY_WEBHOOK_URI));
+        if (StringUtils.isBlank(stringValue)) {
+            throw new IllegalArgumentException(String.format("Parameter %s must not be blank.", PROPERTY_WEBHOOK_URI));
+        }
+        try {
+            return URI.create(stringValue);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(String.format("Parameter %s must be a valid URI (%s): %s",
+                    PROPERTY_WEBHOOK_URI,
+                    stringValue,
+                    e.getMessage()));
+        }
     }
 
-    try {
-      final long longValue = Long.parseLong(String.valueOf(o));
-      if (longValue > 0) {
-        return longValue * 1000;
-      } else {
-        throw new IllegalArgumentException(String.format("Parameter %s must not be 0 or negative (%d).", PROPERTY_RETRY_PAUSE, longValue));
-      }
-    } catch (NumberFormatException e) {
-      log.warn("Failed to process parameter {}: {}", PROPERTY_RETRY_PAUSE, e.getMessage());
-      return _default;
-    }
-  }
+    private URI setProxyURI(Map<String, Object> properties) {
+        final Object propertyObject = properties.get(PROPERTY_PROXY_URI);
+        final String stringValue = String.valueOf(propertyObject);
 
-  private int setRetries(Map<String, Object> properties) {
-    final int _default = 1;
-    if (properties == null) {
-      return _default;
+        if (ObjectUtils.isNotEmpty(propertyObject) && StringUtils.isNotBlank(stringValue)) {
+            try {
+                return URI.create(stringValue);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(String.format("Parameter %s must be a valid URI (%s): %s",
+                        PROPERTY_PROXY_URI,
+                        stringValue,
+                        e.getMessage()));
+            }
+        }
+        return null;
     }
 
-    final Object o = properties.get(PROPERTY_RETRIES);
-    if (o == null) {
-      return _default;
+    private long setPauseBetweenRetries(Map<String, Object> properties) {
+        if (properties == null) {
+            return DEFAULT_PAUSE_BETWEEN_RETRIES;
+        }
+
+        final Object o = properties.get(PROPERTY_RETRY_PAUSE);
+        if (o == null) {
+            return DEFAULT_PAUSE_BETWEEN_RETRIES;
+        }
+
+        try {
+            final long longValue = Long.parseLong(String.valueOf(o));
+            if (longValue > 0) {
+                return longValue * 1000;
+            } else {
+                throw new IllegalArgumentException(String.format("Parameter %s must not be 0 or negative (%d).", PROPERTY_RETRY_PAUSE, longValue));
+            }
+        } catch (NumberFormatException e) {
+            log.warn("Failed to process parameter {}: {}", PROPERTY_RETRY_PAUSE, e.getMessage());
+            return DEFAULT_PAUSE_BETWEEN_RETRIES;
+        }
     }
 
-    try {
-      final int intVal = Integer.parseInt(String.valueOf(o));
-      if (intVal > 0) {
-        return intVal;
-      } else {
-        throw new IllegalArgumentException(String.format("Parameter %s must be greater or equal 1 (%d).", PROPERTY_RETRIES, intVal));
-      }
-    } catch (NumberFormatException e) {
-      log.warn("Failed to process parameter {}: {}", PROPERTY_RETRIES, e.getMessage());
-      return _default;
+    private int setRetries(Map<String, Object> properties) {
+        if (properties == null) {
+            return DEFAULT_RETRIES;
+        }
+
+        final Object o = properties.get(PROPERTY_RETRIES);
+        if (o == null) {
+            return DEFAULT_RETRIES;
+        }
+
+        try {
+            final int intVal = Integer.parseInt(String.valueOf(o));
+            if (intVal > 0) {
+                return intVal;
+            } else {
+                throw new IllegalArgumentException(String.format("Parameter %s must be greater or equal 1 (%d).", PROPERTY_RETRIES, intVal));
+            }
+        } catch (NumberFormatException e) {
+            log.warn("Failed to process parameter {}: {}", PROPERTY_RETRIES, e.getMessage());
+            return DEFAULT_RETRIES;
+        }
     }
-  }
+
+    public static Config.Builder builder() {
+        return new Config.Builder();
+    }
+
+    public static class Builder {
+        private final Map<String, Object> properties = new HashMap<>();
+
+        public Builder withRetries(int retries) {
+            properties.put(PROPERTY_RETRIES, retries);
+            return this;
+        }
+
+        public Builder withPauseBetweenRetries(long pauseBetweenRetries) {
+            properties.put(PROPERTY_RETRY_PAUSE, pauseBetweenRetries);
+            return this;
+        }
+
+        public Builder withWebhookURI(URI webhookURI) {
+            properties.put(PROPERTY_WEBHOOK_URI, webhookURI);
+            return this;
+        }
+
+        public Builder withWebhookURI(String webhookURI) {
+            properties.put(PROPERTY_WEBHOOK_URI, webhookURI);
+            return this;
+        }
+
+        public Builder withProxyURI(URI proxyURI) {
+            properties.put(PROPERTY_PROXY_URI, proxyURI);
+            return this;
+        }
+
+        public Builder withProxyURI(String proxyURI) {
+            properties.put(PROPERTY_PROXY_URI, proxyURI);
+            return this;
+        }
+
+        public Builder withBlocking(boolean blocking) {
+            properties.put(PROPERTY_BLOCKING, blocking);
+            return this;
+        }
+
+        public Config build() {
+            return new Config(properties);
+        }
+    }
 
 }

--- a/src/main/java/com/baloise/open/ms/teams/Config.java
+++ b/src/main/java/com/baloise/open/ms/teams/Config.java
@@ -16,6 +16,7 @@
 package com.baloise.open.ms.teams;
 
 import lombok.Getter;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -26,6 +27,7 @@ import java.util.Map;
 
 @Slf4j
 @Getter
+@ToString
 public final class Config {
     public static final long DEFAULT_PAUSE_BETWEEN_RETRIES = 60000;
     public static final int DEFAULT_RETRIES = 3;

--- a/src/main/java/com/baloise/open/ms/teams/webhook/MessagePublisher.java
+++ b/src/main/java/com/baloise/open/ms/teams/webhook/MessagePublisher.java
@@ -17,9 +17,7 @@ package com.baloise.open.ms.teams.webhook;
 
 import com.baloise.open.ms.teams.Config;
 import com.baloise.open.ms.teams.templates.AdaptiveCard;
-import org.apache.commons.lang3.ObjectUtils;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 
@@ -44,26 +42,23 @@ public interface MessagePublisher {
     String PROPERTY_WEBHOOK_URI = Config.PROPERTY_WEBHOOK_URI;
 
     static MessagePublisher getInstance(String uri) {
-        return getInstance(Map.of(Config.PROPERTY_WEBHOOK_URI, uri));
+        return getInstance(Config.builder().withWebhookURI(uri).build());
     }
 
     static MessagePublisher getInstance(String proxyUri, String uri) {
-        return getInstance(Map.of(
-                Config.PROPERTY_PROXY_URI, proxyUri,
-                Config.PROPERTY_WEBHOOK_URI, uri
-        ));
+        return getInstance(Config.builder()
+                .withWebhookURI(uri)
+                .withProxyURI(proxyUri)
+                .build());
     }
 
     static MessagePublisher getInstance(final Map<String, Object> customProperties) {
-        final Map<String, Object> defaultProperties = getDefaultProperties();
-        if (customProperties != null) {
-            customProperties.forEach((key, value) -> {
-                if (ObjectUtils.isNotEmpty(value)) {
-                    defaultProperties.merge(key, value, (k1, v1) -> value);
-                }
-            });
-        }
-        return new MessagePublisherImpl(defaultProperties);
+        final Config config = new Config(customProperties);
+        return new MessagePublisherImpl(config);
+    }
+
+    static MessagePublisher getInstance(final Config config) {
+        return new MessagePublisherImpl(config);
     }
 
     /**
@@ -75,13 +70,4 @@ public interface MessagePublisher {
      * transmits provided jsonfied String to configured webhook
      */
     ScheduledFuture<?> publish(String jsonBody);
-
-    static Map<String, Object> getDefaultProperties() {
-        final HashMap<String, Object> properties = new HashMap<>();
-        properties.put(Config.PROPERTY_RETRIES, 3);
-        properties.put(Config.PROPERTY_RETRY_PAUSE, 60);
-        properties.put(Config.PROPERTY_WEBHOOK_URI, null);
-        properties.put(Config.PROPERTY_PROXY_URI, null);
-        return properties;
-    }
 }

--- a/src/main/java/com/baloise/open/ms/teams/webhook/MessagePublisher.java
+++ b/src/main/java/com/baloise/open/ms/teams/webhook/MessagePublisher.java
@@ -23,24 +23,6 @@ import java.util.concurrent.ScheduledFuture;
 
 public interface MessagePublisher {
 
-    /**
-     * @deprecated use Config.PROPERTY_RETRIES instead
-     */
-    @Deprecated(forRemoval = true, since = "0.3.1")
-    String PROPERTY_RETRIES = Config.PROPERTY_RETRIES;
-
-    /**
-     * @deprecated use Config.PROPERTY_RETRY_PAUSE instead
-     */
-    @Deprecated(forRemoval = true, since = "0.3.1")
-    String PROPERTY_RETRY_PAUSE = Config.PROPERTY_RETRY_PAUSE;
-
-    /**
-     * @deprecated use Config.PROPERTY_WEBHOOK_URI instead
-     */
-    @Deprecated(forRemoval = true, since = "0.3.1")
-    String PROPERTY_WEBHOOK_URI = Config.PROPERTY_WEBHOOK_URI;
-
     static MessagePublisher getInstance(String uri) {
         return getInstance(Config.builder().withWebhookURI(uri).build());
     }


### PR DESCRIPTION
This is needed when used in a console application as it might not wait for the MessagePublisher to execute before it exits because the publisher creates its own instance of ExecutorService.